### PR TITLE
Make clang-format-diff compatible with Python 3.4

### DIFF
--- a/tools/clang-format/clang-format-diff.py
+++ b/tools/clang-format/clang-format-diff.py
@@ -27,7 +27,7 @@ import difflib
 import re
 import string
 import subprocess
-import StringIO
+import io
 import sys
 
 
@@ -90,9 +90,9 @@ def main():
           ['-lines', str(start_line) + ':' + str(end_line)])
 
   # Reformat files containing changes in place.
-  for filename, lines in lines_by_file.iteritems():
+  for filename, lines in lines_by_file.items():
     if args.i and args.verbose:
-      print 'Formatting', filename
+      print ('Formatting', filename)
     command = [binary, filename]
     if args.i:
       command.append('-i')
@@ -108,13 +108,11 @@ def main():
     if not args.i:
       with open(filename) as f:
         code = f.readlines()
-      formatted_code = StringIO.StringIO(stdout).readlines()
+      formatted_code = io.StringIO(stdout.decode()).readlines()
       diff = difflib.unified_diff(code, formatted_code,
                                   filename, filename,
                                   '(before formatting)', '(after formatting)')
-      diff_string = string.join(diff, '')
-      if len(diff_string) > 0:
-        sys.stdout.write(diff_string)
+      sys.stdout.writelines(diff)
 
 if __name__ == '__main__':
   main()


### PR DESCRIPTION
The script is updated so that it works with Python 2.7 as well as Python 3.x series.
