### PR TITLE
Don't compare line endings when checking format

### DIFF
--- a/tools/clang-format/clang-format-diff.py
+++ b/tools/clang-format/clang-format-diff.py
@@ -107,8 +107,8 @@ def main():
 
     if not args.i:
       with open(filename) as f:
-        code = f.readlines()
-      formatted_code = io.StringIO(stdout.decode()).readlines()
+        code = f.read().split()
+      formatted_code = io.StringIO(stdout.decode()).read().split()
       diff = difflib.unified_diff(code, formatted_code,
                                   filename, filename,
                                   '(before formatting)', '(after formatting)')


### PR DESCRIPTION
By using readlines() when splitting the lines of code for formatted and
unformatted files, clang-format-diff.py reports lines that do not have
diffs as having diffs because the line endings in the original code
differs from the line endings generated by clang-format on Windows. This
fix changes clang-format-diff.py to use read().split() which discards
line endings, fixing this problem.
